### PR TITLE
Added documentation on workflow permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ The following outputs are available (in both modes):
 | `version` | The version after bumping. |
 | `release-notes` | Release notes found in the pull request description. |
 
+## Permissions
+
+The following workflow permissions are required by this action. Depending on your situation these may need to be set explicitly. See [GitHub's documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) for more details.
+
+|Scope|Permission|
+|-|-|
+|`contents`|`write`|
+|`issues`|`read`|
+|`pull-requests`|`read`|
+
 ## Full Example
 
 Create a validation workflow to run whenever a pull request is created or updated. All optional inputs are explicitly set to their default values in the configuration below.


### PR DESCRIPTION
### SUMMARY

GitHub Actions workflows run, by default, with a set of permissions taken from the repository and/or organization in which they reside. These can be further restricted by the workflow's YAML file, but in so doing [any unspecified scopes are automatically set to no access](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token). This requires developers to be aware of the permissions required by their workflows and to explicitly state them.

To that end, the list of permissions required by this action have been added to the README.

### RELEASE NOTES

Added documentation on workflow permissions required.