### PR TITLE
update runtime to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,5 +53,5 @@ outputs:
   skipped:
     description: Indicator if the new version is skipped
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Update the node runtime to v20. This is required by Github. All tests passsed

### SUMMARY

Update to Node 20.

### RELEASE NOTES

Update to Node 20
